### PR TITLE
strip illegal elements, rather than HTML-textifying them

### DIFF
--- a/lib/bleach.js
+++ b/lib/bleach.js
@@ -63,7 +63,7 @@ var ALLOWED_TAGS = [
     "map",
     "mark",
     "menu",
-    "meta",
+    //"meta",
     "meter",
     "nav",
     "noscript",


### PR DESCRIPTION
for thimble textifying made sense, for goggles it creates massive clutter.
