### PR TITLE
bug921779 - Update node-webmaker-i18n version v0.2.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "requirejs": "2.1.8",
     "text": "2.0.9",
-    "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.2.1.tar.gz",
+    "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.2.2.tar.gz",
     "webmaker-ui": "0.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "habitat": "0.4.1",
     "helmet": "0.0.11",
     "htmlsanitizer": "0.0.2",
-    "node-webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.2.1.tar.gz",
+    "node-webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.2.2.tar.gz",
     "knox": "0.8.5",
     "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.6",
     "less-middleware": "0.1.12",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=921779
