### PR TITLE
Bug 936179 - Update all apps to use Webmaker-i18n new API in v0.2.9

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,27 +36,21 @@ var app = express(),
 // Enable template rendering with nunjucks
 nunjucksEnv.express(app);
 
-// List of supported languages - Add them in the .env file
-var listDropdownLang = env.get("SUPPORTED_LANGS"),
-    // We create another array based on listDropdownLang to use it in the i18n.middleware
-    // supported_language which will be modified from the i18n mapping function
-    supportedLanguages = listDropdownLang.slice(0);
+// Setup locales with i18n
+app.use( i18n.middleware({
+  supported_languages: env.get("SUPPORTED_LANGS"),
+  default_lang: "en-US",
+  mappings: env.get("LANG_MAPPINGS"),
+  translation_directory: path.resolve( __dirname, "locale" )
+}));
 
 app.locals({
   GA_ACCOUNT: env.get("GA_ACCOUNT"),
   GA_DOMAIN: env.get("GA_DOMAIN"),
   hostname: env.get("hostname"),
-  supportedLanguages: supportedLanguages,
-  listDropdownLang: listDropdownLang
+  supportedLanguages: i18n.getLanguages(),
+  listDropdownLang: env.get("SUPPORTED_LANGS")
 });
-
-// Setup locales with i18n
-app.use( i18n.middleware({
-  supported_languages: supportedLanguages,
-  default_lang: "en-US",
-  mappings: env.get("LANG_MAPPINGS"),
-  translation_directory: path.resolve( __dirname, "locale" )
-}));
 
 app.use(express.favicon(__dirname + '/public/img/favicon.ico'));
 app.use(express.compress());

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "requirejs": "2.1.8",
     "text": "2.0.9",
-    "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.2.8.tar.gz",
+    "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.2.9.tar.gz",
     "webmaker-ui": "0.0.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "habitat": "0.4.1",
     "helmet": "0.0.11",
     "htmlsanitizer": "0.0.2",
-    "node-webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.2.8.tar.gz",
+    "node-webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.2.9.tar.gz",
     "knox": "0.8.5",
     "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.6",
     "less-middleware": "0.1.12",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=936179
