### PR TITLE
csrf-token rename

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="persona-email" content="{{ email }}">
-    <meta name="X-CSRF-Token" content="{{ csrf }}">
+    <meta name="csrf-token" content="{{ csrf }}">
     <title>{{ gettext("X-Ray Goggles") }}</title>
     <link rel="stylesheet" href="/resources/font-awesome/css/font-awesome.css">
     <link href="//www.mozilla.org/tabzilla/media/css/tabzilla.css" rel="stylesheet">

--- a/views/uproot-dialog.html
+++ b/views/uproot-dialog.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="persona-email" content="{{ email }}">
-    <meta name="X-CSRF-Token" content="{{ csrf }}">
+    <meta name="csrf-token" content="{{ csrf }}">
     <title>{{ gettext("Publish Your Remix") }}</title>
     <link rel="stylesheet" href="../stylesheets/style.css">
     <link rel="stylesheet" href="../stylesheets/dialog.css">


### PR DESCRIPTION
switch from "X-CSRF-Token" as meta name to the validation-passing "csrf-token"

https://bugzilla.mozilla.org/show_bug.cgi?id=930166
