### PR TITLE
folds the <html> tag into the HTML we take off a page

### DIFF
--- a/lib/overrides/uproot.js
+++ b/lib/overrides/uproot.js
@@ -88,8 +88,7 @@
           var ignore = options.ignore.add('script', document);
           var removal = ignore.temporarilyRemove();
           var doctype = makeDoctypeTag(document.doctype);
-          var html = doctype + '\n<html>' +
-                     document.documentElement.innerHTML + '</html>';
+          var html = doctype + document.querySelector("html").outerHTML;
           removal.undo();
           $(base).remove();
           cb.call(elem, html);


### PR DESCRIPTION
uses `outerHTML` on document.querySelector("html"), which is a guaranteed fix on modern browsers and may or may not work on legacy versions of IE and/or Safari
