### PR TITLE
bug975126 - Update webmaker-i18n to v0.3.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "nav-global": "https://github.com/admix/nav-global/archive/v0.1.3.tar.gz",
     "requirejs": "2.1.8",
     "text": "2.0.9",
-    "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.8.tar.gz",
+    "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.11.tar.gz",
     "webmaker-ui": "0.0.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "habitat": "0.4.1",
     "helmet": "0.1.2",
     "htmlsanitizer": "0.0.2",
-    "node-webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.8.tar.gz",
+    "node-webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.11.tar.gz",
     "knox": "0.8.5",
     "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.16",
     "less-middleware": "0.1.12",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=975126
