### PR TITLE
[bug959277] - Added CSP in Report-Only mode into goggles.webmaker.org

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,6 +50,11 @@ nunjucksEnv.express(app);
 
 app.disable("x-powered-by");
 
+// adding Content Security Policy (CSP)
+app.use(middleware.addCSP({
+  personaHost: env.get('PERSONA_HOST')
+}));
+
 // log either to GELF or console
 if (env.get("ENABLE_GELF_LOGS")) {
   messina = require("messina");

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -2,10 +2,62 @@ module.exports = function middlewareConstructor(env) {
 
   var metrics = require('./metrics')(env),
       utils = require("./utils"),
+      hood = require("hood"),
       emulate_s3 = env.get('S3_EMULATION') || !env.get('S3_KEY'),
       knox = emulate_s3 ? require("noxmox").mox : require("knox");
 
   return {
+    /**
+     * Content Security Policy HTTP response header
+     * helps you reduce XSS risks on modern browsers
+     * by declaring what dynamic resources are allowed
+     * to load via a HTTP Header.
+     */
+    addCSP: function ( options ) {
+      return hood.csp({
+        headers: [
+          "Content-Security-Policy-Report-Only"
+        ],
+        policy: {
+          'connect-src': [
+            "'self'"
+          ],
+          'default-src': [
+            "'self'"
+          ],
+          'frame-src': [
+            "'self'",
+            options.personaHost
+          ],
+          'font-src': [
+            "'self'",
+            "https://mozorg.cdn.mozilla.net"
+          ],
+          'img-src': [
+            "*"
+          ],
+          'media-src': [
+            "*"
+          ],
+          'script-src': [
+            "'self'",
+            "http://mozorg.cdn.mozilla.net",
+            "https://mozorg.cdn.mozilla.net",
+            "https://ssl.google-analytics.com",
+            options.personaHost
+
+          ],
+          'style-src': [
+            "'self'",
+            "'unsafe-inline'",
+            "http://mozorg.cdn.mozilla.net",
+            "https://fonts.googleapis.com",
+            "https://mozorg.cdn.mozilla.net",
+          ]
+        }
+      });
+    },
+
     /**
      * The operation for the / route is special,
      * and never an edit or remix.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "glob": "3.2.3",
     "habitat": "0.4.1",
     "helmet": "0.1.2",
+    "hood": "0.2.1",
     "htmlsanitizer": "0.0.2",
     "node-webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.11.tar.gz",
     "knox": "0.8.5",

--- a/public/js/browser-screen.js
+++ b/public/js/browser-screen.js
@@ -3,11 +3,20 @@
 
   var hostname = document.getElementById("browser-screen").getAttribute("data-hostname");
   var localeInfo = document.getElementById("browser-screen").getAttribute("data-localeInfo");
-  
+
   $(window).ready(function() {
 
     $("#bookmarklet-link").attr("href", Webxray.getBookmarkletURL(hostname, localeInfo));
-    $("#bookmarklet-url").val(Webxray.getBookmarkletURL());
+
+    $("#bookmarklet-link").on("click", function(event) {
+      event.preventDefault();
+      var script = document.createElement('script');
+      script.src = '/webxray.js';
+      script.className = 'webxray';
+      script.setAttribute('data-lang',localeInfo);
+      script.setAttribute('data-baseuri', hostname + "/"+localeInfo);
+      document.body.appendChild(script);
+    });
 
     // browser-specific screenshots
     // http://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
@@ -23,7 +32,7 @@
     if (isChrome) {
       browser = "chrome";
     } else if (isSafari) {
-      browser="safari";
+      browser = "safari";
     }
 
     $('#install .screenshot.step1 img').attr('src', 'img/instructions/' + browser + '1.png');

--- a/views/index.html
+++ b/views/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>{{ gettext("X-Ray Goggles") }}</title>
     <link rel="stylesheet" href="/resources/font-awesome/css/font-awesome.css">
-    <link href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet">
+    <link href="https://mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet">
     <link rel="stylesheet" href="/bower/nav-global/nav.css" />
     <link rel="stylesheet" href="stylesheets/style.css">
     <link rel="stylesheet" href="stylesheets/index.css">


### PR DESCRIPTION
-> https://bugzilla.mozilla.org/show_bug.cgi?id=959277
Added CSP to goggles.webmaker.org. The only one thing is that - when you click on "Active X-Ray Goggles" CSP catches inline script somewhere, I am not quite sure where. I would really appreciate to get help finding it. 
I have a suggestion: There is a div: 

```
<div class="bookmarklet"><a href="" id="bookmarklet-link" class="ui-btn"><span>{{ gettext("Activate X-Ray Goggles") }}</span></a></div>
```

It has 'id="bookmarklet-link"' , I guess that it could be a cause for that.
