### PR TITLE
npm no longer automatically installed serve-favicon, body-parser, and…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "app.js",
   "dependencies": {
     "async": "0.2.9",
+    "body-parser": "^1.15.2",
     "bower": "1.3.8",
     "compression": "^1.6.2",
     "express": "^4.14.0",
@@ -20,6 +21,8 @@
     "node-statsd": "0.0.7",
     "noxmox": "0.2.4",
     "nunjucks": "0.1.10",
+    "serve-favicon": "^2.3.0",
+    "serve-static": "^1.11.1",
     "webmaker-download-locales": "^0.2.5",
     "webmaker-i18n": "0.3.28",
     "webmaker-locale-mapping": "0.0.5",


### PR DESCRIPTION
… serve-static - so add them to package.json